### PR TITLE
fix: wrong type in TofeOptions and wrong display in DjsTofeOptions

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -106,7 +106,7 @@ This is the documentation for all options.
 # TofeOptions
 | parameter | type                              | default    | description                 |
 |-----------|-----------------------------------|------------|-----------------------------|
-| hardMode  | number                            | `false`    | Whether to enable hard mode |
+| hardMode  | boolean                           | `false`    | Whether to enable hard mode |
 | players   | [PlayerOptions](#PlayerOptions)[] | *required* | All players' data           |
 
 
@@ -178,5 +178,5 @@ This is the documentation for all options.
 > extends [DjsGameWrapperOptions](#DjsGameWrapperOptions), [TofeOptions](#TofeOptions)
 
 | parameter    | type                                     | default                                       | description         |
-|--------------|------------------------------------------|--------------------------------- -------------|---------------------|
+|--------------|------------------------------------------|-----------------------------------------------|---------------------|
 | strings      | [TofeStrings](./strings.md/#TofeStrings) | [strings.json#tofe](../src/util/strings.json) | The display strings |


### PR DESCRIPTION
## 修改摘要
將docs裡面的[options.md](docs/options.md)的錯字進行變更：
* TofeOptions 的 hardMode type 錯誤，應為boolean而不是number。
* DjsTofeOptions 裡面的表格顯示錯誤。